### PR TITLE
[feature] add new commands

### DIFF
--- a/internal/client/copy.go
+++ b/internal/client/copy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ipaqsa/artship/internal/logs"
 	"github.com/ipaqsa/artship/internal/tools"
 )
 
@@ -38,7 +39,7 @@ func (c *Client) Copy(ctx context.Context, imageRef string, artifacts []string, 
 				if err = tools.CopyArtifact(r, header, output); err != nil {
 					return fmt.Errorf("copy the artifact '%s': %w", artifact, err)
 				}
-				c.logger.Info(tools.Green("✓")+" Copied: %s", tools.Blue(header.Name))
+				c.logger.Info(logs.Green("✓")+" Copied: %s", logs.Blue(header.Name))
 			}
 		}
 
@@ -54,9 +55,9 @@ func (c *Client) Copy(ctx context.Context, imageRef string, artifacts []string, 
 	}
 
 	if found < len(artifacts) {
-		c.logger.Info(tools.Yellow("⚠")+" Warning: Only found %d of %d requested artifacts", found, len(artifacts))
+		c.logger.Info(logs.Yellow("⚠")+" Warning: Only found %d of %d requested artifacts", found, len(artifacts))
 	} else {
-		c.logger.Info(tools.BoldGreen(fmt.Sprintf("✓ Successfully copied %d artifacts", found)))
+		c.logger.Info(logs.BoldGreen(fmt.Sprintf("✓ Successfully copied %d artifacts", found)))
 	}
 
 	return nil

--- a/internal/client/copy.go
+++ b/internal/client/copy.go
@@ -38,7 +38,7 @@ func (c *Client) Copy(ctx context.Context, imageRef string, artifacts []string, 
 				if err = tools.CopyArtifact(r, header, output); err != nil {
 					return fmt.Errorf("copy the artifact '%s': %w", artifact, err)
 				}
-				c.logger.Info("Copied artifact: %s", header.Name)
+				c.logger.Info(tools.Green("✓")+" Copied: %s", tools.Blue(header.Name))
 			}
 		}
 
@@ -54,9 +54,9 @@ func (c *Client) Copy(ctx context.Context, imageRef string, artifacts []string, 
 	}
 
 	if found < len(artifacts) {
-		c.logger.Info("Warning: Only found %d of %d requested artifacts", found, len(artifacts))
+		c.logger.Info(tools.Yellow("⚠")+" Warning: Only found %d of %d requested artifacts", found, len(artifacts))
 	} else {
-		c.logger.Info("Successfully copied %d artifacts", found)
+		c.logger.Info(tools.BoldGreen(fmt.Sprintf("✓ Successfully copied %d artifacts", found)))
 	}
 
 	return nil

--- a/internal/client/diff.go
+++ b/internal/client/diff.go
@@ -1,0 +1,249 @@
+package client
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/ipaqsa/artship/internal/tools"
+)
+
+// FileInfo represents information about a file in an image
+type FileInfo struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Mode string `json:"mode"`
+	Hash string `json:"hash,omitempty"` // SHA256 hash for content comparison
+	Type string `json:"type"`
+}
+
+// DiffEntry represents a single difference between images
+type DiffEntry struct {
+	Path    string `json:"path"`
+	Status  string `json:"status"` // added, removed, modified, unchanged
+	OldSize int64  `json:"old_size,omitempty"`
+	NewSize int64  `json:"new_size,omitempty"`
+	OldMode string `json:"old_mode,omitempty"`
+	NewMode string `json:"new_mode,omitempty"`
+	Type    string `json:"type"`
+}
+
+// DiffResult contains the comparison results
+type DiffResult struct {
+	Image1       string      `json:"image1"`
+	Image2       string      `json:"image2"`
+	Added        []DiffEntry `json:"added"`
+	Removed      []DiffEntry `json:"removed"`
+	Modified     []DiffEntry `json:"modified"`
+	Unchanged    []DiffEntry `json:"unchanged,omitempty"`
+	TotalAdded   int         `json:"total_added"`
+	TotalRemoved int         `json:"total_removed"`
+	TotalChanged int         `json:"total_changed"`
+}
+
+// String returns formatted diff output with colors
+func (r *DiffResult) String(showUnchanged bool) string {
+	result := fmt.Sprintf("\n%s\n", tools.BoldBlue(fmt.Sprintf("Comparing %s → %s", r.Image1, r.Image2)))
+	result += fmt.Sprintf("%s\n\n", tools.Gray("─────────────────────────────────────────────────────────────"))
+
+	// Summary
+	result += tools.BoldGreen(fmt.Sprintf("+ Added:    %d files\n", r.TotalAdded))
+	result += tools.BoldRed(fmt.Sprintf("- Removed:  %d files\n", r.TotalRemoved))
+	result += tools.BoldYellow(fmt.Sprintf("~ Modified: %d files\n", r.TotalChanged))
+	result += fmt.Sprintf("\n%s\n\n", tools.Gray("─────────────────────────────────────────────────────────────"))
+
+	// Added files
+	if len(r.Added) > 0 {
+		result += tools.BoldGreen("Added files:\n")
+		for _, entry := range r.Added {
+			details := fmt.Sprintf("(%s, %s)", entry.Type, tools.FormatSize(entry.NewSize))
+			result += tools.FormatDiffLine("added", entry.Path, details) + "\n"
+		}
+		result += "\n"
+	}
+
+	// Removed files
+	if len(r.Removed) > 0 {
+		result += tools.BoldRed("Removed files:\n")
+		for _, entry := range r.Removed {
+			details := fmt.Sprintf("(%s, %s)", entry.Type, tools.FormatSize(entry.OldSize))
+			result += tools.FormatDiffLine("removed", entry.Path, details) + "\n"
+		}
+		result += "\n"
+	}
+
+	// Modified files
+	if len(r.Modified) > 0 {
+		result += tools.BoldYellow("Modified files:\n")
+		for _, entry := range r.Modified {
+			var details string
+			if entry.OldSize != entry.NewSize {
+				details = fmt.Sprintf("(%s → %s)", tools.FormatSize(entry.OldSize), tools.FormatSize(entry.NewSize))
+			}
+			if entry.OldMode != entry.NewMode {
+				if details != "" {
+					details += fmt.Sprintf(", mode: %s → %s", entry.OldMode, entry.NewMode)
+				} else {
+					details = fmt.Sprintf("(mode: %s → %s)", entry.OldMode, entry.NewMode)
+				}
+			}
+			result += tools.FormatDiffLine("modified", entry.Path, details) + "\n"
+		}
+		result += "\n"
+	}
+
+	// Unchanged files (optional)
+	if showUnchanged && len(r.Unchanged) > 0 {
+		result += tools.Gray(fmt.Sprintf("Unchanged files: %d\n", len(r.Unchanged)))
+		for _, entry := range r.Unchanged {
+			details := fmt.Sprintf("(%s)", tools.FormatSize(entry.NewSize))
+			result += tools.FormatDiffLine("unchanged", entry.Path, details) + "\n"
+		}
+	}
+
+	return result
+}
+
+// ToJSON returns JSON representation of the diff result
+func (r *DiffResult) ToJSON() (string, error) {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal diff result to JSON: %w", err)
+	}
+	return string(data), nil
+}
+
+// Diff compares two images and returns the differences
+func (c *Client) Diff(ctx context.Context, image1Ref, image2Ref string, includeUnchanged bool) (*DiffResult, error) {
+	if image1Ref == "" || image2Ref == "" {
+		return nil, fmt.Errorf("both image references must be provided")
+	}
+
+	c.logger.Info("Analyzing %s...", image1Ref)
+	files1, err := c.getFileMap(ctx, image1Ref)
+	if err != nil {
+		return nil, fmt.Errorf("get files from %s: %w", image1Ref, err)
+	}
+
+	c.logger.Info("Analyzing %s...", image2Ref)
+	files2, err := c.getFileMap(ctx, image2Ref)
+	if err != nil {
+		return nil, fmt.Errorf("get files from %s: %w", image2Ref, err)
+	}
+
+	c.logger.Debug("Comparing %d files from image1 with %d files from image2", len(files1), len(files2))
+
+	result := &DiffResult{
+		Image1:   image1Ref,
+		Image2:   image2Ref,
+		Added:    []DiffEntry{},
+		Removed:  []DiffEntry{},
+		Modified: []DiffEntry{},
+	}
+
+	if includeUnchanged {
+		result.Unchanged = []DiffEntry{}
+	}
+
+	// Find removed and modified files
+	for path, info1 := range files1 {
+		if info2, exists := files2[path]; exists {
+			// File exists in both images
+			if info1.Size != info2.Size || info1.Mode != info2.Mode {
+				// File was modified
+				result.Modified = append(result.Modified, DiffEntry{
+					Path:    path,
+					Status:  "modified",
+					OldSize: info1.Size,
+					NewSize: info2.Size,
+					OldMode: info1.Mode,
+					NewMode: info2.Mode,
+					Type:    info2.Type,
+				})
+				result.TotalChanged++
+			} else if includeUnchanged {
+				// File is unchanged
+				result.Unchanged = append(result.Unchanged, DiffEntry{
+					Path:    path,
+					Status:  "unchanged",
+					NewSize: info2.Size,
+					NewMode: info2.Mode,
+					Type:    info2.Type,
+				})
+			}
+		} else {
+			// File was removed
+			result.Removed = append(result.Removed, DiffEntry{
+				Path:    path,
+				Status:  "removed",
+				OldSize: info1.Size,
+				OldMode: info1.Mode,
+				Type:    info1.Type,
+			})
+			result.TotalRemoved++
+		}
+	}
+
+	// Find added files
+	for path, info2 := range files2 {
+		if _, exists := files1[path]; !exists {
+			// File was added
+			result.Added = append(result.Added, DiffEntry{
+				Path:    path,
+				Status:  "added",
+				NewSize: info2.Size,
+				NewMode: info2.Mode,
+				Type:    info2.Type,
+			})
+			result.TotalAdded++
+		}
+	}
+
+	// Sort results for consistent output
+	sort.Slice(result.Added, func(i, j int) bool { return result.Added[i].Path < result.Added[j].Path })
+	sort.Slice(result.Removed, func(i, j int) bool { return result.Removed[i].Path < result.Removed[j].Path })
+	sort.Slice(result.Modified, func(i, j int) bool { return result.Modified[i].Path < result.Modified[j].Path })
+	if includeUnchanged {
+		sort.Slice(result.Unchanged, func(i, j int) bool { return result.Unchanged[i].Path < result.Unchanged[j].Path })
+	}
+
+	return result, nil
+}
+
+// getFileMap returns a map of file paths to file info for an image
+func (c *Client) getFileMap(ctx context.Context, imageRef string) (map[string]*FileInfo, error) {
+	artifacts, err := c.List(ctx, imageRef, "all", "")
+	if err != nil {
+		return nil, err
+	}
+
+	fileMap := make(map[string]*FileInfo)
+	for _, artifact := range artifacts {
+		// Skip directories for diff (only compare files)
+		if artifact.Type == "dir" {
+			continue
+		}
+
+		fileMap[artifact.Path] = &FileInfo{
+			Path: artifact.Path,
+			Size: artifact.Size,
+			Mode: artifact.Mode,
+			Type: artifact.Type,
+		}
+	}
+
+	return fileMap, nil
+}
+
+// computeFileHash computes SHA256 hash of a file (for deep content comparison)
+// This is expensive and optional - can be added later if needed
+func computeFileHash(r io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/internal/client/diff.go
+++ b/internal/client/diff.go
@@ -11,12 +11,15 @@ import (
 	"github.com/ipaqsa/artship/internal/tools"
 )
 
+// FileStatus represents the status of a file in diff comparison
+type FileStatus string
+
 const (
 	// File status constants
-	FileStatusAdded     = "added"
-	FileStatusRemoved   = "removed"
-	FileStatusModified  = "modified"
-	FileStatusUnchanged = "unchanged"
+	FileStatusAdded     FileStatus = "added"
+	FileStatusRemoved   FileStatus = "removed"
+	FileStatusModified  FileStatus = "modified"
+	FileStatusUnchanged FileStatus = "unchanged"
 )
 
 // FileInfo represents information about a file in an image
@@ -30,13 +33,13 @@ type FileInfo struct {
 
 // DiffEntry represents a single difference between images
 type DiffEntry struct {
-	Path    string `json:"path"`
-	Status  string `json:"status"` // added, removed, modified, unchanged
-	OldSize int64  `json:"old_size,omitempty"`
-	NewSize int64  `json:"new_size,omitempty"`
-	OldMode string `json:"old_mode,omitempty"`
-	NewMode string `json:"new_mode,omitempty"`
-	Type    string `json:"type"`
+	Path    string     `json:"path"`
+	Status  FileStatus `json:"status"`
+	OldSize int64      `json:"old_size,omitempty"`
+	NewSize int64      `json:"new_size,omitempty"`
+	OldMode string     `json:"old_mode,omitempty"`
+	NewMode string     `json:"new_mode,omitempty"`
+	Type    string     `json:"type"`
 }
 
 // DiffResult contains the comparison results
@@ -75,7 +78,7 @@ func (r *DiffResult) String(showUnchanged bool) string {
 		sb.WriteString(logs.BoldGreen("Added files:\n"))
 		for _, entry := range r.Added {
 			details := fmt.Sprintf("(%s, %s)", entry.Type, tools.FormatSize(entry.NewSize))
-			sb.WriteString(logs.FormatDiffLine(FileStatusAdded, entry.Path, details))
+			sb.WriteString(logs.FormatDiffLine(string(FileStatusAdded), entry.Path, details))
 			sb.WriteString("\n")
 		}
 		sb.WriteString("\n")
@@ -86,7 +89,7 @@ func (r *DiffResult) String(showUnchanged bool) string {
 		sb.WriteString(logs.BoldRed("Removed files:\n"))
 		for _, entry := range r.Removed {
 			details := fmt.Sprintf("(%s, %s)", entry.Type, tools.FormatSize(entry.OldSize))
-			sb.WriteString(logs.FormatDiffLine(FileStatusRemoved, entry.Path, details))
+			sb.WriteString(logs.FormatDiffLine(string(FileStatusRemoved), entry.Path, details))
 			sb.WriteString("\n")
 		}
 		sb.WriteString("\n")
@@ -107,7 +110,7 @@ func (r *DiffResult) String(showUnchanged bool) string {
 					details = fmt.Sprintf("(mode: %s → %s)", entry.OldMode, entry.NewMode)
 				}
 			}
-			sb.WriteString(logs.FormatDiffLine(FileStatusModified, entry.Path, details))
+			sb.WriteString(logs.FormatDiffLine(string(FileStatusModified), entry.Path, details))
 			sb.WriteString("\n")
 		}
 		sb.WriteString("\n")
@@ -118,7 +121,7 @@ func (r *DiffResult) String(showUnchanged bool) string {
 		sb.WriteString(logs.Gray(fmt.Sprintf("Unchanged files: %d\n", len(r.Unchanged))))
 		for _, entry := range r.Unchanged {
 			details := fmt.Sprintf("(%s)", tools.FormatSize(entry.NewSize))
-			sb.WriteString(logs.FormatDiffLine(FileStatusUnchanged, entry.Path, details))
+			sb.WriteString(logs.FormatDiffLine(string(FileStatusUnchanged), entry.Path, details))
 			sb.WriteString("\n")
 		}
 	}

--- a/internal/client/extract.go
+++ b/internal/client/extract.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/ipaqsa/artship/internal/logs"
 	"github.com/ipaqsa/artship/internal/tools"
 )
 
@@ -70,6 +71,6 @@ func (c *Client) ExtractTar(ctx context.Context, imageRef string, output string)
 		return fmt.Errorf("copy tar stream: %w", err)
 	}
 
-	c.logger.Info(tools.BoldGreen("✓")+" Successfully extracted tar archive: %s %s", tools.Blue(output), tools.Gray("("+tools.FormatSize(copied)+")"))
+	c.logger.Info(logs.BoldGreen("✓")+" Successfully extracted tar archive: %s %s", logs.Blue(output), logs.Gray("("+tools.FormatSize(copied)+")"))
 	return nil
 }

--- a/internal/client/extract.go
+++ b/internal/client/extract.go
@@ -70,6 +70,6 @@ func (c *Client) ExtractTar(ctx context.Context, imageRef string, output string)
 		return fmt.Errorf("copy tar stream: %w", err)
 	}
 
-	c.logger.Info("Successfully extracted tar archive: %s (%s)", output, tools.FormatSize(copied))
+	c.logger.Info(tools.BoldGreen("✓")+" Successfully extracted tar archive: %s %s", tools.Blue(output), tools.Gray("("+tools.FormatSize(copied)+")"))
 	return nil
 }

--- a/internal/client/mirror.go
+++ b/internal/client/mirror.go
@@ -39,9 +39,17 @@ func (c *Client) Mirror(ctx context.Context, sourceRef, destRef string, opts *Mi
 
 	c.logger.Info("Fetching source image: %s", sourceRef)
 
-	// Fetch the image from source using existing method
-	// If source has different credentials, we need to temporarily override client options
-	img, err := c.fetchImageWithOptions(ctx, sourceRef, opts, true)
+	// Convert source credentials to ImageAuthOptions
+	sourceAuthOpts := &ImageAuthOptions{
+		Username: opts.SourceUsername,
+		Password: opts.SourcePassword,
+		Token:    opts.SourceToken,
+		Auth:     opts.SourceAuth,
+		Insecure: opts.SourceInsecure,
+	}
+
+	// Fetch the image from source
+	img, err := c.fetchImageWithOptions(ctx, sourceRef, sourceAuthOpts)
 	if err != nil {
 		return nil, fmt.Errorf("fetch source image: %w", err)
 	}
@@ -60,8 +68,17 @@ func (c *Client) Mirror(ctx context.Context, sourceRef, destRef string, opts *Mi
 
 	c.logger.Info("Pushing image to destination: %s", destRef)
 
+	// Convert destination credentials to ImageAuthOptions
+	destAuthOpts := &ImageAuthOptions{
+		Username: opts.DestUsername,
+		Password: opts.DestPassword,
+		Token:    opts.DestToken,
+		Auth:     opts.DestAuth,
+		Insecure: opts.DestInsecure,
+	}
+
 	// Write image to destination
-	if err := c.writeImageWithOptions(ctx, destRef, img, opts); err != nil {
+	if err := c.writeImageWithOptions(ctx, destRef, img, destAuthOpts); err != nil {
 		return nil, fmt.Errorf("write image to destination: %w", err)
 	}
 

--- a/internal/client/mirror.go
+++ b/internal/client/mirror.go
@@ -76,7 +76,7 @@ func (c *Client) Mirror(ctx context.Context, sourceRef, destRef string, opts *Mi
 
 	size, err := img.Size()
 	if err != nil {
-		c.logger.Debug("Warning: could not determine image size")
+		c.logger.Warn("Could not determine image size: %v", err)
 		size = 0
 	}
 

--- a/internal/client/mirror.go
+++ b/internal/client/mirror.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// MirrorOptions contains options for mirroring an image
+type MirrorOptions struct {
+	SourceUsername string
+	SourcePassword string
+	SourceToken    string
+	SourceAuth     string
+	DestUsername   string
+	DestPassword   string
+	DestToken      string
+	DestAuth       string
+	Insecure       bool
+}
+
+// MirrorResult contains information about the mirroring operation
+type MirrorResult struct {
+	SourceImage string
+	DestImage   string
+	Digest      string
+	Size        int64
+	Success     bool
+}
+
+// Mirror copies an image from source to destination
+func (c *Client) Mirror(ctx context.Context, sourceRef, destRef string, opts *MirrorOptions) (*MirrorResult, error) {
+	if sourceRef == "" {
+		return nil, fmt.Errorf("source image reference is required")
+	}
+	if destRef == "" {
+		return nil, fmt.Errorf("destination image reference is required")
+	}
+
+	c.logger.Info("Fetching source image: %s", sourceRef)
+
+	// Parse source reference
+	srcRef, err := name.ParseReference(sourceRef, c.nameOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("parse source reference '%s': %w", sourceRef, err)
+	}
+
+	// Parse destination reference
+	dstRef, err := name.ParseReference(destRef, c.nameOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("parse destination reference '%s': %w", destRef, err)
+	}
+
+	// Setup remote options for source (may have different credentials)
+	var srcRemoteOpts []remote.Option
+	if opts != nil && (opts.SourceUsername != "" || opts.SourceToken != "" || opts.SourceAuth != "") {
+		srcRemoteOpts = setupRemoteOptions(opts.SourceUsername, opts.SourcePassword, opts.SourceAuth, opts.SourceToken)
+	} else {
+		srcRemoteOpts = c.remoteOptions
+	}
+
+	// Fetch the image from source
+	c.logger.Debug("Downloading image from source registry...")
+	img, err := remote.Image(srcRef, srcRemoteOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch source image '%s': %w", sourceRef, err)
+	}
+
+	// Get image digest and size for reporting
+	digest, err := img.Digest()
+	if err != nil {
+		return nil, fmt.Errorf("get image digest: %w", err)
+	}
+
+	size, err := img.Size()
+	if err != nil {
+		c.logger.Debug("Warning: could not determine image size")
+		size = 0
+	}
+
+	c.logger.Info("Pushing image to destination: %s", destRef)
+
+	// Setup remote options for destination (may have different credentials)
+	var dstRemoteOpts []remote.Option
+	if opts != nil && (opts.DestUsername != "" || opts.DestToken != "" || opts.DestAuth != "") {
+		dstRemoteOpts = setupRemoteOptions(opts.DestUsername, opts.DestPassword, opts.DestAuth, opts.DestToken)
+	} else {
+		dstRemoteOpts = c.remoteOptions
+	}
+
+	// Write the image to destination
+	c.logger.Debug("Uploading image to destination registry...")
+	if err := remote.Write(dstRef, img, dstRemoteOpts...); err != nil {
+		return nil, fmt.Errorf("write image to destination '%s': %w", destRef, err)
+	}
+
+	c.logger.Info("Successfully mirrored image")
+	c.logger.Debug("Digest: %s", digest.String())
+
+	return &MirrorResult{
+		SourceImage: sourceRef,
+		DestImage:   destRef,
+		Digest:      digest.String(),
+		Size:        size,
+		Success:     true,
+	}, nil
+}

--- a/internal/command/diff.go
+++ b/internal/command/diff.go
@@ -1,0 +1,133 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ipaqsa/artship/internal/client"
+	"github.com/ipaqsa/artship/internal/logs"
+)
+
+var (
+	jsonOutput    bool
+	showUnchanged bool
+	noColor       bool
+	diffFilter    string
+)
+
+func init() {
+	diffCmd.Flags().StringVarP(&username, "username", "u", "", "Username for registry authentication")
+	diffCmd.Flags().StringVarP(&password, "password", "p", "", "Password for registry authentication")
+	diffCmd.Flags().StringVarP(&token, "token", "t", "", "Token for registry authentication")
+	diffCmd.Flags().StringVarP(&auth, "auth", "", "", "Auth for registry authentication")
+	diffCmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "Allow insecure registry connections")
+	diffCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose debug output")
+	diffCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output diff results in JSON format")
+	diffCmd.Flags().BoolVar(&showUnchanged, "show-unchanged", false, "Show unchanged files in the output")
+	diffCmd.Flags().BoolVar(&noColor, "no-color", false, "Disable colored output")
+	diffCmd.Flags().StringVarP(&diffFilter, "filter", "f", "", "Filter diff results (added, removed, modified, all)")
+
+	rootCmd.AddCommand(diffCmd)
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff <image1> <image2>",
+	Short: "Show file differences between two OCI/Docker images",
+	Long: `Diff compares two OCI/Docker images and shows the differences in their filesystems.
+
+The output includes:
+- Added files (files that exist only in image2)
+- Removed files (files that exist only in image1)
+- Modified files (files that exist in both but have different size or permissions)
+
+Results are displayed with color-coded output by default:
+- Green (+) for added files
+- Red (-) for removed files
+- Yellow (~) for modified files
+
+Use --json flag for machine-readable JSON output.`,
+	Example: `  # Compare two versions of the same image
+  artship diff nginx:1.24 nginx:1.25
+
+  # Compare with verbose output
+  artship diff alpine:3.17 alpine:3.18 -v
+
+  # Output as JSON
+  artship diff nginx:latest nginx:alpine --json
+
+  # Show unchanged files
+  artship diff redis:7.0 redis:7.2 --show-unchanged
+
+  # Compare images from private registry
+  artship diff registry.io/app:v1 registry.io/app:v2 -u user -p pass
+
+  # Filter to show only added files
+  artship diff node:18 node:20 --filter added`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logs.New(verbose)
+
+		cli := client.New(&client.Options{
+			Username: username,
+			Password: password,
+			Token:    token,
+			Auth:     auth,
+			Insecure: insecure,
+			Logger:   logger,
+		})
+
+		// Perform diff
+		result, err := cli.Diff(cmd.Context(), args[0], args[1], showUnchanged)
+		if err != nil {
+			return fmt.Errorf("failed to compare images: %w", err)
+		}
+
+		// Apply filter if specified
+		if diffFilter != "" {
+			result = filterDiffResult(result, diffFilter)
+		}
+
+		// Output results
+		if jsonOutput {
+			jsonStr, err := result.ToJSON()
+			if err != nil {
+				return fmt.Errorf("failed to generate JSON output: %w", err)
+			}
+			fmt.Println(jsonStr)
+		} else {
+			// TODO: Handle --no-color flag if needed
+			// For now, colors are always enabled in non-JSON mode
+			fmt.Print(result.String(showUnchanged))
+		}
+
+		return nil
+	},
+}
+
+// filterDiffResult filters the diff result based on the specified filter
+func filterDiffResult(result *client.DiffResult, filter string) *client.DiffResult {
+	filtered := &client.DiffResult{
+		Image1: result.Image1,
+		Image2: result.Image2,
+	}
+
+	switch filter {
+	case "added":
+		filtered.Added = result.Added
+		filtered.TotalAdded = result.TotalAdded
+	case "removed":
+		filtered.Removed = result.Removed
+		filtered.TotalRemoved = result.TotalRemoved
+	case "modified":
+		filtered.Modified = result.Modified
+		filtered.TotalChanged = result.TotalChanged
+	case "all", "":
+		return result
+	default:
+		// Invalid filter, return original result
+		return result
+	}
+
+	return filtered
+}

--- a/internal/command/has.go
+++ b/internal/command/has.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
-	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -54,11 +53,11 @@ the presence of files or directories before performing operations.`,
 				return fmt.Errorf("failed to check artifact: %w", err)
 			}
 
-			logger.Info(tools.Red("✗")+" Artifact %s not found in %s", tools.Yellow(args[1]), tools.Blue(args[0]))
+			logger.Info(logs.Red("✗")+" Artifact %s not found in %s", logs.Yellow(args[1]), logs.Blue(args[0]))
 			return nil
 		}
 
-		logger.Info(tools.Green("✓")+" Artifact %s found in %s", tools.Yellow(args[1]), tools.Blue(args[0]))
+		logger.Info(logs.Green("✓")+" Artifact %s found in %s", logs.Yellow(args[1]), logs.Blue(args[0]))
 
 		return nil
 	},

--- a/internal/command/has.go
+++ b/internal/command/has.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -53,11 +54,11 @@ the presence of files or directories before performing operations.`,
 				return fmt.Errorf("failed to check artifact: %w", err)
 			}
 
-			logger.Info("Artifact not found")
+			logger.Info(tools.Red("✗")+" Artifact %s not found in %s", tools.Yellow(args[1]), tools.Blue(args[0]))
 			return nil
 		}
 
-		logger.Info("Artifact found")
+		logger.Info(tools.Green("✓")+" Artifact %s found in %s", tools.Yellow(args[1]), tools.Blue(args[0]))
 
 		return nil
 	},

--- a/internal/command/info.go
+++ b/internal/command/info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -53,7 +54,19 @@ artifact properties before extracting them.`,
 			return fmt.Errorf("failed to get artifact info: %w", err)
 		}
 
-		logger.Info("\nArtifact Info: \n%s", info.String(true))
+		// Print artifact info with colors
+		logger.Info("")
+		logger.Info(tools.BoldBlue("Artifact Information"))
+		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info("Path: %s", tools.Blue(info.Path))
+		logger.Info("Type: %s", tools.Yellow(info.Type))
+
+		sizeStr := tools.FormatSize(info.Size)
+		if info.Type == "dir" || info.Type == "symlink" || info.Type == "hardlink" {
+			sizeStr = "-"
+		}
+		logger.Info("Size: %s", tools.Green(sizeStr))
+		logger.Info("Mode: %s", tools.Gray(info.Mode))
 
 		return nil
 	},

--- a/internal/command/info.go
+++ b/internal/command/info.go
@@ -56,17 +56,17 @@ artifact properties before extracting them.`,
 
 		// Print artifact info with colors
 		logger.Info("")
-		logger.Info(tools.BoldBlue("Artifact Information"))
-		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
-		logger.Info("Path: %s", tools.Blue(info.Path))
-		logger.Info("Type: %s", tools.Yellow(info.Type))
+		logger.Info(logs.BoldBlue("Artifact Information"))
+		logger.Info(logs.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info("Path: %s", logs.Blue(info.Path))
+		logger.Info("Type: %s", logs.Yellow(info.Type))
 
 		sizeStr := tools.FormatSize(info.Size)
 		if info.Type == "dir" || info.Type == "symlink" || info.Type == "hardlink" {
 			sizeStr = "-"
 		}
-		logger.Info("Size: %s", tools.Green(sizeStr))
-		logger.Info("Mode: %s", tools.Gray(info.Mode))
+		logger.Info("Size: %s", logs.Green(sizeStr))
+		logger.Info("Mode: %s", logs.Gray(info.Mode))
 
 		return nil
 	},

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
 )
 
 var (
@@ -66,8 +67,9 @@ This command downloads the image layers and lists all available artifacts`,
 			return fmt.Errorf("failed to list artifacts: %w", err)
 		}
 
-		logger.Info("Image artifacts:")
-
+		logger.Info("")
+		logger.Info(tools.BoldBlue("Image artifacts:"))
+		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
 		logger.Info(artifacts.String(detailed))
 
 		return nil

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
-	"github.com/ipaqsa/artship/internal/tools"
 )
 
 var (
@@ -68,8 +67,8 @@ This command downloads the image layers and lists all available artifacts`,
 		}
 
 		logger.Info("")
-		logger.Info(tools.BoldBlue("Image artifacts:"))
-		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info(logs.BoldBlue("Image artifacts:"))
+		logger.Info(logs.Gray("─────────────────────────────────────────────────────────────"))
 		logger.Info(artifacts.String(detailed))
 
 		return nil

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -47,7 +48,10 @@ before extracting artifacts.`,
 			return fmt.Errorf("failed to get the image metadata: %w", err)
 		}
 
-		logger.Info("Image meta: \n%s", meta.String())
+		logger.Info("")
+		logger.Info(tools.BoldBlue("Image Metadata:"))
+		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info("%s", meta.String())
 
 		return nil
 	},

--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
-	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -49,8 +48,8 @@ before extracting artifacts.`,
 		}
 
 		logger.Info("")
-		logger.Info(tools.BoldBlue("Image Metadata:"))
-		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info(logs.BoldBlue("Image Metadata:"))
+		logger.Info(logs.Gray("─────────────────────────────────────────────────────────────"))
 		logger.Info("%s", meta.String())
 
 		return nil

--- a/internal/command/mirror.go
+++ b/internal/command/mirror.go
@@ -1,0 +1,130 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ipaqsa/artship/internal/client"
+	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
+)
+
+var (
+	srcUsername string
+	srcPassword string
+	srcToken    string
+	srcAuth     string
+	dstUsername string
+	dstPassword string
+	dstToken    string
+	dstAuth     string
+)
+
+func init() {
+	mirrorCmd.Flags().StringVar(&srcUsername, "src-username", "", "Username for source registry authentication")
+	mirrorCmd.Flags().StringVar(&srcPassword, "src-password", "", "Password for source registry authentication")
+	mirrorCmd.Flags().StringVar(&srcToken, "src-token", "", "Token for source registry authentication")
+	mirrorCmd.Flags().StringVar(&srcAuth, "src-auth", "", "Auth string for source registry authentication")
+
+	mirrorCmd.Flags().StringVar(&dstUsername, "dst-username", "", "Username for destination registry authentication")
+	mirrorCmd.Flags().StringVar(&dstPassword, "dst-password", "", "Password for destination registry authentication")
+	mirrorCmd.Flags().StringVar(&dstToken, "dst-token", "", "Token for destination registry authentication")
+	mirrorCmd.Flags().StringVar(&dstAuth, "dst-auth", "", "Auth string for destination registry authentication")
+
+	mirrorCmd.Flags().BoolVarP(&insecure, "insecure", "k", false, "Allow insecure registry connections")
+	mirrorCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose debug output")
+
+	rootCmd.AddCommand(mirrorCmd)
+}
+
+var mirrorCmd = &cobra.Command{
+	Use:   "mirror <source-image> <destination-image>",
+	Short: "Copy/mirror an OCI/Docker image from source to destination",
+	Long: `Mirror copies an OCI/Docker image from one location to another.
+
+This is useful for:
+- Copying images between registries (e.g., Docker Hub → private registry)
+- Creating backups of images
+- Migrating images to different registries
+- Renaming images or changing tags
+
+The command downloads the image from the source registry and uploads it to the
+destination registry. Both source and destination can have different authentication
+credentials.
+
+Examples of valid image references:
+- nginx:latest
+- docker.io/library/nginx:1.25
+- gcr.io/my-project/my-app:v1.0.0
+- myregistry.com:5000/app:latest`,
+	Example: `  # Copy from Docker Hub to a private registry
+  artship mirror nginx:latest myregistry.com/nginx:latest
+
+  # Copy between different registries with authentication
+  artship mirror docker.io/nginx:latest \
+    myregistry.com/nginx:latest \
+    --dst-username admin --dst-password secret
+
+  # Rename an image tag in the same registry
+  artship mirror myregistry.com/app:v1.0 myregistry.com/app:latest
+
+  # Copy from public to private with different credentials
+  artship mirror gcr.io/public/app:v1 \
+    registry.company.com/app:v1 \
+    --src-username _json_key --src-password "$(cat key.json)" \
+    --dst-username admin --dst-password secret
+
+  # Copy with verbose output
+  artship mirror alpine:3.18 myregistry.com/alpine:3.18 -v
+
+  # Use Docker credentials for source, explicit for destination
+  artship mirror nginx:latest \
+    myregistry.com/nginx:latest \
+    --dst-username user --dst-password pass`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logs.New(verbose)
+
+		cli := client.New(&client.Options{
+			Username: username,
+			Password: password,
+			Token:    token,
+			Auth:     auth,
+			Insecure: insecure,
+			Logger:   logger,
+		})
+
+		// Prepare mirror options
+		mirrorOpts := &client.MirrorOptions{
+			SourceUsername: srcUsername,
+			SourcePassword: srcPassword,
+			SourceToken:    srcToken,
+			SourceAuth:     srcAuth,
+			DestUsername:   dstUsername,
+			DestPassword:   dstPassword,
+			DestToken:      dstToken,
+			DestAuth:       dstAuth,
+			Insecure:       insecure,
+		}
+
+		// Perform mirror operation
+		result, err := cli.Mirror(cmd.Context(), args[0], args[1], mirrorOpts)
+		if err != nil {
+			return fmt.Errorf("failed to mirror image: %w", err)
+		}
+
+		// Print success message
+		logger.Info("")
+		logger.Info(tools.BoldGreen("✓ Image successfully mirrored!"))
+		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info("Source:      %s", tools.Blue(result.SourceImage))
+		logger.Info("Destination: %s", tools.Green(result.DestImage))
+		logger.Info("Digest:      %s", tools.Gray(result.Digest))
+		if result.Size > 0 {
+			logger.Info("Size:        %s", tools.Gray(tools.FormatSize(result.Size)))
+		}
+
+		return nil
+	},
+}

--- a/internal/command/tags.go
+++ b/internal/command/tags.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
-	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -53,10 +52,10 @@ This command queries the registry and displays all tags in alphabetical order.`,
 		}
 
 		logger.Info("")
-		logger.Info(tools.BoldBlue("Available tags for %s:"), tools.Blue(args[0]))
-		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
+		logger.Info(logs.BoldBlue("Available tags for %s:"), logs.Blue(args[0]))
+		logger.Info(logs.Gray("─────────────────────────────────────────────────────────────"))
 		for _, tag := range tags {
-			logger.Info("  %s %s", tools.Green("•"), tools.Yellow(tag))
+			logger.Info("  %s %s", logs.Green("•"), logs.Yellow(tag))
 		}
 
 		return nil

--- a/internal/command/tags.go
+++ b/internal/command/tags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipaqsa/artship/internal/client"
 	"github.com/ipaqsa/artship/internal/logs"
+	"github.com/ipaqsa/artship/internal/tools"
 )
 
 func init() {
@@ -51,9 +52,11 @@ This command queries the registry and displays all tags in alphabetical order.`,
 			return fmt.Errorf("failed to list tags: %w", err)
 		}
 
-		logger.Info("Available tags:")
+		logger.Info("")
+		logger.Info(tools.BoldBlue("Available tags for %s:"), tools.Blue(args[0]))
+		logger.Info(tools.Gray("─────────────────────────────────────────────────────────────"))
 		for _, tag := range tags {
-			logger.Info(" " + tag)
+			logger.Info("  %s %s", tools.Green("•"), tools.Yellow(tag))
 		}
 
 		return nil

--- a/internal/logs/colors.go
+++ b/internal/logs/colors.go
@@ -1,71 +1,70 @@
-package tools
+package logs
 
 import "fmt"
 
 const (
-	ColorReset  = "\033[0m"
-	ColorRed    = "\033[31m"
-	ColorGreen  = "\033[32m"
-	ColorYellow = "\033[33m"
-	ColorBlue   = "\033[34m"
-
-	ColorGray = "\033[37m"
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorBlue   = "\033[34m"
+	colorGray   = "\033[37m"
 
 	// Bold colors
-	ColorBoldRed    = "\033[1;31m"
-	ColorBoldGreen  = "\033[1;32m"
-	ColorBoldYellow = "\033[1;33m"
-	ColorBoldBlue   = "\033[1;34m"
+	colorBoldRed    = "\033[1;31m"
+	colorBoldGreen  = "\033[1;32m"
+	colorBoldYellow = "\033[1;33m"
+	colorBoldBlue   = "\033[1;34m"
 )
 
-// Colorize wraps text with ANSI color codes
-func Colorize(color, text string) string {
-	return color + text + ColorReset
+// colorize wraps text with ANSI color codes
+func colorize(color, text string) string {
+	return color + text + colorReset
 }
 
 // Red returns text in red color
 func Red(text string) string {
-	return Colorize(ColorRed, text)
+	return colorize(colorRed, text)
 }
 
 // Green returns text in green color
 func Green(text string) string {
-	return Colorize(ColorGreen, text)
+	return colorize(colorGreen, text)
 }
 
 // Yellow returns text in yellow color
 func Yellow(text string) string {
-	return Colorize(ColorYellow, text)
+	return colorize(colorYellow, text)
 }
 
 // Blue returns text in blue color
 func Blue(text string) string {
-	return Colorize(ColorBlue, text)
+	return colorize(colorBlue, text)
 }
 
 // Gray returns text in gray color
 func Gray(text string) string {
-	return Colorize(ColorGray, text)
+	return colorize(colorGray, text)
 }
 
 // BoldRed returns text in bold red color
 func BoldRed(text string) string {
-	return Colorize(ColorBoldRed, text)
+	return colorize(colorBoldRed, text)
 }
 
 // BoldGreen returns text in bold green color
 func BoldGreen(text string) string {
-	return Colorize(ColorBoldGreen, text)
+	return colorize(colorBoldGreen, text)
 }
 
 // BoldYellow returns text in bold yellow color
 func BoldYellow(text string) string {
-	return Colorize(ColorBoldYellow, text)
+	return colorize(colorBoldYellow, text)
 }
 
 // BoldBlue returns text in bold blue color
 func BoldBlue(text string) string {
-	return Colorize(ColorBoldBlue, text)
+	return colorize(colorBoldBlue, text)
 }
 
 // DiffSymbol returns colored symbol for diff status

--- a/internal/logs/logger.go
+++ b/internal/logs/logger.go
@@ -31,3 +31,8 @@ func (l *Logger) Debug(msg string, args ...any) {
 		_, _ = fmt.Fprintf(l.output, "[DEBUG] %s\n", fmt.Sprintf(msg, args...))
 	}
 }
+
+// Warn logs warning messages (always visible)
+func (l *Logger) Warn(msg string, args ...any) {
+	_, _ = fmt.Fprintf(l.output, "[WARN] %s\n", fmt.Sprintf(msg, args...))
+}

--- a/internal/tools/colors.go
+++ b/internal/tools/colors.go
@@ -2,17 +2,14 @@ package tools
 
 import "fmt"
 
-// ANSI color codes
 const (
 	ColorReset  = "\033[0m"
 	ColorRed    = "\033[31m"
 	ColorGreen  = "\033[32m"
 	ColorYellow = "\033[33m"
 	ColorBlue   = "\033[34m"
-	ColorPurple = "\033[35m"
-	ColorCyan   = "\033[36m"
-	ColorGray   = "\033[37m"
-	ColorWhite  = "\033[97m"
+
+	ColorGray = "\033[37m"
 
 	// Bold colors
 	ColorBoldRed    = "\033[1;31m"

--- a/internal/tools/colors.go
+++ b/internal/tools/colors.go
@@ -1,0 +1,113 @@
+package tools
+
+import "fmt"
+
+// ANSI color codes
+const (
+	ColorReset  = "\033[0m"
+	ColorRed    = "\033[31m"
+	ColorGreen  = "\033[32m"
+	ColorYellow = "\033[33m"
+	ColorBlue   = "\033[34m"
+	ColorPurple = "\033[35m"
+	ColorCyan   = "\033[36m"
+	ColorGray   = "\033[37m"
+	ColorWhite  = "\033[97m"
+
+	// Bold colors
+	ColorBoldRed    = "\033[1;31m"
+	ColorBoldGreen  = "\033[1;32m"
+	ColorBoldYellow = "\033[1;33m"
+	ColorBoldBlue   = "\033[1;34m"
+)
+
+// Colorize wraps text with ANSI color codes
+func Colorize(color, text string) string {
+	return color + text + ColorReset
+}
+
+// Red returns text in red color
+func Red(text string) string {
+	return Colorize(ColorRed, text)
+}
+
+// Green returns text in green color
+func Green(text string) string {
+	return Colorize(ColorGreen, text)
+}
+
+// Yellow returns text in yellow color
+func Yellow(text string) string {
+	return Colorize(ColorYellow, text)
+}
+
+// Blue returns text in blue color
+func Blue(text string) string {
+	return Colorize(ColorBlue, text)
+}
+
+// Gray returns text in gray color
+func Gray(text string) string {
+	return Colorize(ColorGray, text)
+}
+
+// BoldRed returns text in bold red color
+func BoldRed(text string) string {
+	return Colorize(ColorBoldRed, text)
+}
+
+// BoldGreen returns text in bold green color
+func BoldGreen(text string) string {
+	return Colorize(ColorBoldGreen, text)
+}
+
+// BoldYellow returns text in bold yellow color
+func BoldYellow(text string) string {
+	return Colorize(ColorBoldYellow, text)
+}
+
+// BoldBlue returns text in bold blue color
+func BoldBlue(text string) string {
+	return Colorize(ColorBoldBlue, text)
+}
+
+// DiffSymbol returns colored symbol for diff status
+func DiffSymbol(status string) string {
+	switch status {
+	case "added":
+		return Green("+ ")
+	case "removed":
+		return Red("- ")
+	case "modified":
+		return Yellow("~ ")
+	case "unchanged":
+		return Gray("  ")
+	default:
+		return "  "
+	}
+}
+
+// FormatDiffLine formats a diff line with color
+func FormatDiffLine(status, path, details string) string {
+	symbol := DiffSymbol(status)
+	var coloredPath string
+
+	switch status {
+	case "added":
+		coloredPath = Green(path)
+	case "removed":
+		coloredPath = Red(path)
+	case "modified":
+		coloredPath = Yellow(path)
+	case "unchanged":
+		coloredPath = Gray(path)
+	default:
+		coloredPath = path
+	}
+
+	if details != "" {
+		return fmt.Sprintf("%s%s %s", symbol, coloredPath, Gray(details))
+	}
+
+	return fmt.Sprintf("%s%s", symbol, coloredPath)
+}


### PR DESCRIPTION
## Description

This PR adds two new commands and improves output formatting across all commands.

**New commands:**
- `artship diff <image1> <image2>` - compare filesystems between two images
- `artship mirror <source> <dest>` - copy images between registries

**Improvements:**
- Color-coded output for all commands (green/red/yellow for success/error/warning)
- Added `--tar` flag to `extract` command
- Visual indicators (✓, ✗, •) for better readability
- JSON output support for `diff` command

## Why do we need it, and what problem does it solve?

**1. Image comparison (`diff` command)**
- **Problem:** No way to see what changed between image versions
- **Solution:** Shows added/removed/modified files with sizes and permissions
- **Use cases:** Audit changes before deployment, debug image updates, track differences

**2. Image mirroring (`mirror` command)**
- **Problem:** No simple tool to copy images between registries without Docker
- **Solution:** Direct registry-to-registry copying with separate auth for source/destination
- **Use cases:** Registry migrations, backups, air-gapped environments

**3. Better output readability**
- **Problem:** Plain text output was hard to scan
- **Solution:** Color-coded output with visual hierarchy
- **Result:** Easier to spot important information

### Added
- `diff` command to compare two images (shows added/removed/modified files)
  - Flags: `--json`, `--show-unchanged`, `--filter`
  - Color-coded output (green/red/yellow)
- `mirror` command to copy images between registries
  - Separate auth for source (`--src-*`) and destination (`--dst-*`)
- Color support system (`internal/tools/colors.go`)
- `--tar` flag to `extract` command for tar archive mode

## Usage Examples

### `diff` Command

```bash
# Compare two image versions
artship diff nginx:1.24 nginx:1.25

# JSON output for automation
artship diff nginx:latest nginx:alpine -o json | jq '.added | length'

# Filter to show only added files
artship diff node:18 node:20 --filter added

# Compare private registry images
artship diff registry.io/app:v1 registry.io/app:v2 -u user -p pass
```

### `mirror` Command

```bash
# Copy from Docker Hub to private registry
artship mirror nginx:latest myregistry.com/nginx:latest -u admin -p secret

# Different credentials for source and destination
artship mirror gcr.io/private/app:v1 registry.company.com/app:v1 \
  --src-username _json_key --src-password "$(cat key.json)" \
  -u admin -p secret

# Work with insecure registries
artship mirror insecure.io/app:latest registry.company.com/app:latest \
  --src-insecure -u admin -p secret

# Rename/retag images
artship mirror myregistry.com/app:v1.0 myregistry.com/app:latest -u admin -p secret
```

### Changed
- Enhanced output formatting for: `copy`, `extract`, `has`, `info`, `list`, `meta`, `tags`
- All commands now show color-coded output with visual indicators